### PR TITLE
Converts RouterInterface to nullable on Helper constructor

### DIFF
--- a/src/Templating/Helper/GravatarHelper.php
+++ b/src/Templating/Helper/GravatarHelper.php
@@ -30,7 +30,7 @@ class GravatarHelper implements GravatarHelperInterface
      * @param GravatarApi $api
      * @param RouterInterface|null $router
      */
-    public function __construct(GravatarApi $api, RouterInterface $router = null)
+    public function __construct(GravatarApi $api, ?RouterInterface $router)
     {
         $this->api = $api;
         $this->router = $router;


### PR DESCRIPTION
Using PHP 8.4.1 , when running phpunit and the web app the following warning is being presented.
I fixed that.

```
Remaining indirect deprecation notices (1)

  1x: Pyrrah\GravatarBundle\Templating\Helper\GravatarHelper::__construct(): Implicitly marking parameter $router as nullable is deprecated, the explicit nullable type must be used instead
    1x in DefendantTest::setup from App\Tests\Integration

```