### PR TITLE
Fix: add missing default image options (retro and robohash)

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -34,7 +34,7 @@ class Configuration implements ConfigurationInterface
 
                 // Default imageset to use (mm deprecated, kept for oldest versions)
                 ->enumNode('default')
-                    ->values(['404', 'mp', 'identicon', 'monsterid', 'wavatar', 'mm'])
+                    ->values(['404', 'mp', 'identicon', 'monsterid', 'wavatar', 'retro', 'robohash', 'mm'])
                     ->defaultValue('mp')
                 ->end()
 


### PR DESCRIPTION
The `retro` and `robohash` options were missing from the allowed `default` options, so this adds them in.

See [the official Gravatar docs](https://docs.gravatar.com/api/avatars/images/#:~:text=retro%3A%20awesome%20generated%2C%208%2Dbit%20arcade%2Dstyle%20pixelated%20faces) for reference.