### PR TITLE
Remove support for Symfony 4 and 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This bundle allows you to display your avatar anywhere on your site, via the Gra
 Requirements
 ------------
 
-* Symfony 4.4 to 7
-* PHP 7.1.3 or higher
+* Symfony 6.4 to 7.x
+* PHP 8.1 or higher
 * A [Gravatar account][link-gravatar-signup] - it's free!
 
 Installation

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "pyrrah/gravatar-bundle",
-    "description": "The simple way to use Gravatar API for Symfony 4.4 to 7",
+    "description": "The simple way to use Gravatar API for Symfony 6 and Symfony 7",
     "homepage": "https://github.com/Pyrrah/GravatarBundle",
-    "keywords": ["pyrrah", "gravatar", "picture gravatar", "gravatar symfony4", "gravatar symfony5", "gravatar symfony6", "gravatar symfony7"],
+    "keywords": ["pyrrah", "gravatar", "picture gravatar", "gravatar symfony6", "gravatar symfony7"],
     "type": "symfony-bundle",
     "license": "MIT",
     "authors": [{
@@ -23,12 +23,12 @@
     },
     "prefer-stable": true,
     "require": {
-        "php": ">=7.1.3",
-        "symfony/framework-bundle" : "^4.2.7|^5.4.4|^6.0.4|^7.0",
-        "symfony/templating": "^4.0|^5.0|^6.0|^7.0"
+        "php": ">=8.1",
+        "symfony/framework-bundle" : "^6.4|^7.0",
+        "symfony/templating": "^6.4|^7.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.3|^6.1|^7.0"
+        "symfony/phpunit-bridge": "^6.1|^7.0"
     },
     "suggest" : {
         "twig/twig" : "For Gravatar twig extension usage"
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "v1.4.x-dev"
+            "dev-main": "v1.5.x-dev"
         }
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -11,13 +11,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('pyrrah_gravatar');
 
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC for symfony/config < 4.2
-            $rootNode = $treeBuilder->root('pyrrah_gravatar');
-        }
-
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode
             ->children()
                 // Size in pixels


### PR DESCRIPTION
I'm removing support for Symfony 4 and Symfony 5 from the bundle.
Symfony 4 has been deprecated for quite some time, and Symfony 5 is patched until 2029, without any significant changes.

This decision is motivated by focusing the bundle on the Stable Release and Long-Term Support Release (LTS) versions of Symfony, currently the 6.4.* and 7.3.* branches.

I recommend **upgrading your projects to Symfony 6.4.x or 7.3.x**, if you haven't already.