### PR TITLE
Choosing the output format for the avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ Installation
   ```
 
 > [!NOTE]
-> The "format" option is specific to the bundle to choose the output format :
->  * url (default option): returns the Gravatar image's https URL
->  * base64: image generated in base64 format from the Gravatar URL
+> The format option is specific to the bundle to choose the output format :
+>  * url (default) : returns the https URL of the Gravatar image
+>  * base64 : returns a base64-formatted image generated from the Gravatar URL
+>
+> By using the "base64" option, you hide from your users the email hash used in the Gravatar URL.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -32,7 +32,18 @@ Installation
     rating: "g"
     size: 80
     default: "mp"
+    format: "base64"
   ```
+
+The "format" option is specific to the bundle to choose the output format :
+  * url (default option): returns the Gravatar image's https URL
+  * base64: image generated in base64 format from the Gravatar URL
+
+> [!NOTE]
+> How to improve privacy?
+>
+> You can choose "base64" for the format option.
+> With this option, instead of the default Gravatar URL containing the email hash, a dynamically generated image will be displayed.
 
 Usage
 -----
@@ -46,7 +57,7 @@ All you have to do is use the helper like this example:
 Or with parameters:
 
 ```html
-<img src="<?php echo $view['gravatar']->getUrl('alias@domain.tld', '80', 'g', 'defaultimage.png') ?>" />
+<img src="<?php echo $view['gravatar']->getUrl('alias@domain.tld', '80', 'g', 'defaultimage.png', 'base64') ?>" />
 ```
 
 The only required parameter is the email adress. The rest have default values.

--- a/README.md
+++ b/README.md
@@ -35,15 +35,10 @@ Installation
     format: "base64"
   ```
 
-The "format" option is specific to the bundle to choose the output format :
-  * url (default option): returns the Gravatar image's https URL
-  * base64: image generated in base64 format from the Gravatar URL
-
 > [!NOTE]
-> How to improve privacy?
->
-> You can choose "base64" for the format option.
-> With this option, instead of the default Gravatar URL containing the email hash, a dynamically generated image will be displayed.
+> The "format" option is specific to the bundle to choose the output format :
+>  * url (default option): returns the Gravatar image's https URL
+>  * base64: image generated in base64 format from the Gravatar URL
 
 Usage
 -----

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -32,6 +32,12 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('mp')
                 ->end()
 
+                // Default format to return to the user (gravatar URL or base64 image)
+                ->enumNode('format')
+                    ->values(['url', 'base64'])
+                    ->defaultValue('url')
+                ->end()
+
                 // [Deprecated] Return an URL secure for Gravatar
                 ->booleanNode('secure')
                     ->defaultTrue()

--- a/src/DependencyInjection/PyrrahGravatarExtension.php
+++ b/src/DependencyInjection/PyrrahGravatarExtension.php
@@ -25,5 +25,6 @@ final class PyrrahGravatarExtension extends Extension
         $definition->replaceArgument(0, $config['size']);
         $definition->replaceArgument(1, $config['rating']);
         $definition->replaceArgument(2, $config['default']);
+        $definition->replaceArgument(3, $config['format']);
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,6 +14,7 @@
             <argument /> <!-- will be filled in with size dynamically -->
             <argument /> <!-- will be filled in with rating dynamically -->
             <argument /> <!-- will be filled in with default dynamically -->
+            <argument /> <!-- will be filled in with format dynamically -->
         </service>
 
         <service id="templating.helper.gravatar" class="%templating.helper.gravatar.class%">

--- a/src/Templating/Helper/GravatarHelper.php
+++ b/src/Templating/Helper/GravatarHelper.php
@@ -39,33 +39,33 @@ class GravatarHelper implements GravatarHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = true)
+    public function getUrl($email, $size = null, $rating = null, $default = null, $format = null)
     {
-        return $this->api->getUrl($email, $size, $rating, $default, $this->isSecure($secure));
+        return $this->api->getUrl($email, $size, $rating, $default, $format);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = true)
+    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $format = null)
     {
-        return $this->api->getUrlForHash($hash, $size, $rating, $default, $this->isSecure($secure));
+        return $this->api->getUrlForHash($hash, $size, $rating, $default, $format);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getProfileUrl($email, $secure = true)
+    public function getProfileUrl($email)
     {
-        return $this->api->getProfileUrl($email, $this->isSecure($secure));
+        return $this->api->getProfileUrl($email);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getProfileUrlForHash($hash, $secure = true)
+    public function getProfileUrlForHash($hash)
     {
-        return $this->api->getProfileUrlForHash($hash, $this->isSecure($secure));
+        return $this->api->getProfileUrlForHash($hash);
     }
 
     public function render($email, array $options = array())
@@ -73,9 +73,9 @@ class GravatarHelper implements GravatarHelperInterface
         $size = isset($options['size']) ? $options['size'] : null;
         $rating = isset($options['rating']) ? $options['rating'] : null;
         $default = isset($options['default']) ? $options['default'] : null;
-        $secure = $this->isSecure();
+        $format = isset($options['format']) ? $options['format'] : null;
 
-        return $this->api->getUrl($email, $size, $rating, $default, $secure);
+        return $this->api->getUrl($email, $size, $rating, $default, $format);
     }
 
     /**
@@ -94,25 +94,5 @@ class GravatarHelper implements GravatarHelperInterface
     public function getName()
     {
         return 'gravatar';
-    }
-
-    /**
-     * Returns true if avatar should be fetched over secure connection.
-     *
-     * @param mixed $preset
-     *
-     * @return bool
-     */
-    protected function isSecure($preset = true)
-    {
-        if (null !== $preset) {
-            return (bool) $preset;
-        }
-
-        if (null === $this->router) {
-            return false;
-        }
-
-        return 'https' == strtolower($this->router->getContext()->getScheme());
     }
 }

--- a/src/Templating/Helper/GravatarHelperInterface.php
+++ b/src/Templating/Helper/GravatarHelperInterface.php
@@ -11,11 +11,11 @@ interface GravatarHelperInterface
      * @param int    $size
      * @param string $rating
      * @param string $default
-     * @param bool   $secure
+     * @param bool   $format
      *
      * @return string
      */
-    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = true);
+    public function getUrl($email, $size = null, $rating = null, $default = null, $format = null);
 
     /**
      * Returns a url for a gravatar for a given hash.
@@ -24,11 +24,11 @@ interface GravatarHelperInterface
      * @param int    $size
      * @param string $rating
      * @param string $default
-     * @param bool   $secure
+     * @param bool   $format
      *
      * @return string
      */
-    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = true);
+    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $format = null);
 
     /**
      * Returns a url for a gravatar profile.
@@ -38,7 +38,7 @@ interface GravatarHelperInterface
      *
      * @return string
      */
-    public function getProfileUrl($email, $secure = true);
+    public function getProfileUrl($email);
 
     /**
      * Returns a url for a gravatar profile, for the given hash.
@@ -48,7 +48,7 @@ interface GravatarHelperInterface
      *
      * @return string
      */
-    public function getProfileUrlForHash($hash, $secure = true);
+    public function getProfileUrlForHash($hash);
 
     /**
      * Returns true if a avatar could be found for the email.

--- a/src/Twig/GravatarExtension.php
+++ b/src/Twig/GravatarExtension.php
@@ -43,33 +43,33 @@ class GravatarExtension extends AbstractExtension implements GravatarHelperInter
     /**
      * {@inheritdoc}
      */
-    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = true)
+    public function getUrl($email, $size = null, $rating = null, $default = null, $format = null)
     {
-        return $this->baseHelper->getUrl($email, $size, $rating, $default, $secure);
+        return $this->baseHelper->getUrl($email, $size, $rating, $default, $format);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = true)
+    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $format = null)
     {
-        return $this->baseHelper->getUrlForHash($hash, $size, $rating, $default, $secure);
+        return $this->baseHelper->getUrlForHash($hash, $size, $rating, $default, $format);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getProfileUrl($email, $secure = true)
+    public function getProfileUrl($email)
     {
-        return $this->baseHelper->getProfileUrl($email, $secure);
+        return $this->baseHelper->getProfileUrl($email);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getProfileUrlForHash($hash, $secure = true)
+    public function getProfileUrlForHash($hash)
     {
-        return $this->baseHelper->getProfileUrlForHash($hash, $secure);
+        return $this->baseHelper->getProfileUrlForHash($hash);
     }
 
     /**


### PR DESCRIPTION
The user can now choose the format they want for the avatar returned to the user: "url" or "base64."
If option "format" is not defined, the Gravatar URL is returned by default.

**Why this option ?**
The Gravatar URL is generated from the user's email hash (currently md5, next sha256). Unfortunately, it's possible to deduce the user's email address. Therefore, we offer the base64 option, which generates an image from the return provided by Gravatar and masks the user's hash.